### PR TITLE
updated line `if inside`

### DIFF
--- a/mpldatacursor/datacursor.py
+++ b/mpldatacursor/datacursor.py
@@ -737,7 +737,7 @@ class DataCursor(object):
         for artist in self.artists:
             fixed_event = event_axes_data(event, artist.axes)
             inside, info = contains(artist, fixed_event)
-            if inside:
+            if inside and artist.get_visible():
                 fig = artist.figure
                 
                 # If magnetic is True, update event to closest data points


### PR DESCRIPTION
`if inside and artist.get_visible():` just this change prevents creation of annotations  for artists that are not visible.
This is handy if users are controlling visibility or artists for plots that have multiple lines.